### PR TITLE
fix: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git"
+    "url": "git+https://github.com/w5s/project-config.git"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/browserslist-config"
   },
   "license": "MIT",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/commitlint-config"
   },
   "license": "MIT",

--- a/packages/configurator-core/package.json
+++ b/packages/configurator-core/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/configurator-core"
   },
   "license": "MIT",

--- a/packages/conventional-changelog/package.json
+++ b/packages/conventional-changelog/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/conventional-changelog"
   },
   "license": "MIT",

--- a/packages/cspell-config/package.json
+++ b/packages/cspell-config/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/cspell-config"
   },
   "license": "MIT",

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/dev"
   },
   "license": "MIT",

--- a/packages/eslint-config-ignore/package.json
+++ b/packages/eslint-config-ignore/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/eslint-config-ignore"
   },
   "license": "MIT",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/eslint-config"
   },
   "license": "MIT",

--- a/packages/mrm-preset/package.json
+++ b/packages/mrm-preset/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/mrm-preset"
   },
   "license": "MIT",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/prettier-config"
   },
   "license": "MIT",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/tsconfig"
   },
   "license": "MIT",

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh@github.com:w5s/project-config.git",
+    "url": "git+https://github.com/w5s/project-config.git",
     "directory": "packages/tsdown-config"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
- replace the malformed SSH-style GitHub repository URL with the public HTTPS Git URL across package manifests
- keep existing package repository directories unchanged

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @w5s/commitlint-config pack --pack-destination /tmp/w5s-pack`
- inspected the packed `@w5s/commitlint-config` manifest and confirmed `repository.url` is `git+https://github.com/w5s/project-config.git`
- `pnpm --filter @w5s/commitlint-config test`
- `pnpm --filter @w5s/commitlint-config lint`
- `pnpm --filter @w5s/commitlint-config typecheck`
- `git diff --check`